### PR TITLE
feat: Match Cursor's double-press behavior for AI Chat toggle (cmd+])

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,8 +85,7 @@ async function generateKeybindings(extensionPath: string) {
         {
             key: 'ctrl+]',
             mac: 'cmd+]',
-            command: 'aichat.newchataction',
-            when: '!view.workbench.panel.aichat.view.visible',
+            command: 'aichat.newchataction'
         },
         {
             key: 'ctrl+]',


### PR DESCRIPTION
Aims to resolve #6 

# Issue
Currently, our AI Chat toggle behavior differs from Cursor editor's implementation. We should align our cmd+] behavior with how Cursor handles double-press cmd+L for consistency across AI-enabled editors.

**Current Behavior:**
- First press of cmd+] opens the ai chat panel
- Second press of cmd+] does not close the ai chat panel (unless we toggle to the editor)

**Expected Behavior:**
- Match Cursor editor's double-press pattern:
  - Single press of cmd+] opens the chat panel
  - Quick double press of cmd+] should toggle the chat panel
- This mirrors Cursor's implementation where double-pressing cmd+L toggles their AI chat view

**Technical Changes:**
```typescript
const additionalShortcuts = [
    {
        key: 'ctrl+]',
        mac: 'cmd+]',
        command: 'aichat.newchataction',
    },
    // ... other shortcuts
];
```
- Remove the `when` clause restriction from `aichat.newchataction`
- Ensures smooth toggle behavior on repeated keypresses

**Reference:**
- Cursor Editor's cmd+L double-press behavior serves as the UX benchmark
- This change will provide feature parity with Cursor's chat toggle implementation